### PR TITLE
Add config and template and memory example

### DIFF
--- a/docs/examples/mistral/chat.py
+++ b/docs/examples/mistral/chat.py
@@ -4,22 +4,34 @@ Mistral thru CTransformers.
 """
 
 import panel as pn
-from ctransformers import AutoModelForCausalLM
+from ctransformers import AutoConfig, AutoModelForCausalLM, Config
 
 pn.extension()
+
+INSTRUCTIONS = "You are a friendly chat bot willing to help out the user."
+
+
+def apply_template(instructions, contents):
+    text_row = f"""<s>[INST]{instructions} {contents}[/INST]"""
+    return text_row
 
 
 async def callback(contents: str, user: str, instance: pn.widgets.ChatInterface):
     if "mistral" not in llms:
         instance.placeholder_text = "Downloading model; please wait..."
+        config = AutoConfig(
+            config=Config(
+                temperature=0.5, max_new_tokens=2048, context_length=2048, gpu_layers=1
+            ),
+        )
         llms["mistral"] = AutoModelForCausalLM.from_pretrained(
             "TheBloke/Mistral-7B-Instruct-v0.1-GGUF",
             model_file="mistral-7b-instruct-v0.1.Q4_K_M.gguf",
-            gpu_layers=1,
+            config=config,
         )
 
     llm = llms["mistral"]
-    response = llm(contents, stream=True, max_new_tokens=1000)
+    response = llm(apply_template(INSTRUCTIONS, contents), stream=True)
     message = ""
     for token in response:
         message += token
@@ -27,7 +39,12 @@ async def callback(contents: str, user: str, instance: pn.widgets.ChatInterface)
 
 
 llms = {}
-chat_interface = pn.widgets.ChatInterface(callback=callback, callback_user="Mistral")
+chat_interface = pn.widgets.ChatInterface(
+    callback=callback,
+    callback_user="Mistral",
+    reset_on_send=True,
+    widgets=[pn.widgets.TextAreaInput(auto_grow=True, rows=1, max_rows=3)],
+)
 chat_interface.send(
     "Send a message to get a reply from Mistral!", user="System", respond=False
 )

--- a/docs/examples/mistral/chat.py
+++ b/docs/examples/mistral/chat.py
@@ -43,7 +43,6 @@ chat_interface = pn.widgets.ChatInterface(
     callback=callback,
     callback_user="Mistral",
     reset_on_send=True,
-    widgets=[pn.widgets.TextAreaInput(auto_grow=True, rows=1, max_rows=3)],
 )
 chat_interface.send(
     "Send a message to get a reply from Mistral!", user="System", respond=False

--- a/docs/examples/mistral/chat_memory.py
+++ b/docs/examples/mistral/chat_memory.py
@@ -1,0 +1,57 @@
+"""
+Demonstrates how to use the ChatInterface widget to create a chatbot using
+Mistral thru CTransformers.
+"""
+
+import panel as pn
+from ctransformers import AutoConfig, AutoModelForCausalLM, Config
+
+pn.extension()
+
+SYSTEM_INSTRUCTIONS = "Reply to the user in a friendly manner."
+
+
+def apply_template(contents, history):
+    if not history:
+        text_row = f"""<s>[INST]{SYSTEM_INSTRUCTIONS} {contents}[/INST]"""
+    else:
+        prior_input_output = "\n".join(history)
+        text_row = f"""{prior_input_output}[INST]{contents}[/INST]"""
+    return text_row
+
+
+async def callback(contents: str, user: str, instance: pn.widgets.ChatInterface):
+    if "mistral" not in llms:
+        instance.placeholder_text = "Downloading model; please wait..."
+        config = AutoConfig(
+            config=Config(
+                temperature=0.5, max_new_tokens=2048, context_length=2048, gpu_layers=1
+            ),
+        )
+        llms["mistral"] = AutoModelForCausalLM.from_pretrained(
+            "TheBloke/Mistral-7B-Instruct-v0.1-GGUF",
+            model_file="mistral-7b-instruct-v0.1.Q4_K_M.gguf",
+            config=config,
+        )
+
+    llm = llms["mistral"]
+    prompt = apply_template(contents, history)
+    response = llm(prompt, stream=True)
+    message = ""
+    for token in response:
+        message += token
+        yield message
+    history.append(prompt + message + "</s>")
+
+
+llms = {}
+history = []
+chat_interface = pn.widgets.ChatInterface(
+    callback=callback,
+    callback_user="Mistral",
+    reset_on_send=True,
+)
+chat_interface.send(
+    "Send a message to get a reply from Mistral!", user="System", respond=False
+)
+chat_interface.servable()

--- a/docs/examples/mistral/chat_memory.py
+++ b/docs/examples/mistral/chat_memory.py
@@ -1,6 +1,6 @@
 """
 Demonstrates how to use the ChatInterface widget to create a chatbot using
-Mistral thru CTransformers.
+Mistral thru CTransformers that includes a memory of the conversation history.
 """
 
 import panel as pn


### PR DESCRIPTION
Improves example on how to config and adjust instructions.

<img width="466" alt="image" src="https://github.com/holoviz-topics/panel-chat-examples/assets/15331990/afdefe61-061f-4a6a-8ac3-5c885ff11114">
