### PR TITLE
Make plotly stretch

### DIFF
--- a/docs/examples/openai/openai_chat_with_hvplot.py
+++ b/docs/examples/openai/openai_chat_with_hvplot.py
@@ -104,6 +104,7 @@ The type is `{DATA.__class__.__name__}`. The `dtypes` are
 {DATA.dtypes}
 ```"""
 
+hvplot.extension("plotly")
 pn.extension(
     "plotly",
     raw_css=[CSS_TO_BE_UPSTREAMED_TO_PANEL],


### PR DESCRIPTION
Currently plotly plots generated when you "talk with hvPlot" will not stretch.

This solves the issue. See https://github.com/holoviz/panel/issues/6026#issuecomment-1855819798