### PR TITLE
Create mistral_api_chat.py

### DIFF
--- a/docs/examples/mistral/mistral_api_chat.py
+++ b/docs/examples/mistral/mistral_api_chat.py
@@ -1,0 +1,28 @@
+import panel as pn
+from mistralai.client import MistralClient
+from mistralai.models.chat_completion import ChatMessage
+
+pn.extension()
+
+
+async def callback(contents: str, user: str, instance: pn.chat.ChatInterface):
+    messages = []
+    messages.append(ChatMessage(role="user", content=contents))
+
+    mistral_response = ""
+    for chunk in client.chat_stream(model="mistral-tiny", messages=messages):
+        response = chunk.choices[0].delta.content
+        if response is not None:
+            mistral_response += response
+            yield mistral_response
+
+    if mistral_response:
+        messages.append(ChatMessage(role="assistant", content=mistral_response))
+
+
+client = MistralClient()  # api_key=os.environ.get("MISTRAL_API_KEY", None),
+chat_interface = pn.chat.ChatInterface(callback=callback, callback_user="Mistral AI")
+chat_interface.send(
+    "Send a message to get a reply from Mistral AI!", user="System", respond=False
+)
+chat_interface.servable()


### PR DESCRIPTION
Add example code to create a Panel chat interface using the new [Mistral AI API](https://docs.mistral.ai/api#operation/createChatCompletion) and [Mistral Python client](https://github.com/mistralai/client-python/tree/main).